### PR TITLE
Opic 58 Map OPHeap directly to a file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,9 @@ install:
 - sudo dpkg -i libcmocka0_1.0.1-3_amd64.deb
 - sudo dpkg -i libcmocka-dev_1.0.1-3_amd64.deb
 - cd ..
-before_script:
-- sudo sysctl vm.overcommit_memory=1
+# After version 8, we should not require overcommit memory anymore
+# before_script:
+# - sudo sysctl vm.overcommit_memory=1
 script:
 - autoreconf -vif
 - ./configure

--- a/README.md
+++ b/README.md
@@ -3,66 +3,92 @@ Object Persistence In C (Beta)
 
 [![Build Status](https://travis-ci.org/dryman/opic.svg?branch=master)](https://travis-ci.org/dryman/opic)
 
-OPIC is a revolutionary serialization framework for C.  Unlike traditional
-approaches which walk through the in-memory objects and write it to disk, OPIC
-itself is a memory allocator where all the objects created with it have the same
-representation in memory and on disk. "Serializing/deserializing" is extreme
-cheap with OPIC, because the memory can write directly to disk, and the
-deserialization is simply a mmap syscall.
 
+OPIC is a revolutionary serialization framework for C.  Unlike
+traditional approaches which walk through the in-memory objects and
+write it to disk, OPIC itself is a memory allocator where all the
+objects created are backed by a memory mapped file.  To save the
+current snapshot of objects , simply call `OPHeapMSync()` and all the
+changes are flushed to disk. Regular serialization may take several
+seconds, even up to minutes to write large amont of data.  In
+contrast, OPIC only takes few milliseconds to perform both read and
+write.  For reading, `mmap()` system call only takes 0.0005 seconds to
+map the file into memory region. The data is not loaded into memory
+until the program access it. For writing, `msync()` is quite fast as
+well.
 
-OPIC is suitable for building database indexes, key-value store, or even search
-engines. At the moment of writing we provide a hash table to demonstrate how
-easy it is to build an embedded key-value store engine.
+SYNOPSIS --------
 
-SYNOPSIS
---------
+Using OPIC we can quickly draft out a poor man's key value store.
+OPIC provides two types of hash table: `OPHashTable` for fixed length
+key (like `CHAR(20)` in database), and `PascalHashTable` for length
+varying key. `PascalHashTable` provide a short string optimization
+similar to what [C++ does][sso]. Instead of using 24 bytes for inline
+string in hash table buckets, user can specify the size of the inline
+buffer. If the size of the key exceeds the inline buffer, extra space
+is allocated in OPIC to hold the key and the bucket would represent as
+pointer to key instead of inline key.
+
+See the example below on how to write a mini key-value store in
+few lines of C.
+
+[sso]: https://stackoverflow.com/questions/21694302/what-are-the-mechanics-of-short-string-optimization-in-libc?answertab=active#tab-top
 
 ```c
-#include "opic/op_malloc.h"
-#include "opic/hash/op_hash_table.h"
+// gcc -lopic $(log4c-config --libs) opic_write.c -o opic_write
+#include <opic/op_malloc.h>
+#include <opic/hash/pascal_hash_table.h>
 
-struct S1
+int main(int argc, char** argv)
 {
-  opref_t s2_ref;
-};
+  uint64_t data = 10;
+  OPHeap* heap = OPHeapOpen("myheap", O_RDWR | O_CREAT);
+  PascalHashTable* table = PHNew(heap,
+                                 20,     // table size: 20 elements
+                                 0.7,    // table load: 70%
+                                 10,     // inline size for key
+                                 sizeof(data)); // value size
+  // store table ptr at slot 0
+  OPHeapStorePtr(heap, table, 0);
 
-struct S2
+  // "ABC" stored inline in table.
+  PHInsert(table,   // Object oriented C. The object instance is the first arg.
+           "ABC",   // The key we want to store
+           4,       // Length of the key (3 char + 1 NULL)
+           &data);  // pointer to value, value would get copied to table.
+  data++;
+  PHInsert(table, "DEF", 4, &data);  // DEF stored inline in table.
+  data++;
+  PHInsert(table, "This is a long string", 22, &data);
+  // key stored as pointer to a string with length of 22 (last byte NULL).
+
+  OPHeapClose(heap);
+  return 0;
+}
+
+// gcc-6 -lopic $(log4c-config --libs) opic_read.c -o opic_read
+#include <inttypes.h>
+#include <opic/op_malloc.h>
+#include <opic/hash/pascal_hash_table.h>
+
+int main(int argc, char** argv)
 {
-  char[1024] data;
-};
+  OPHeap* heap = OPHeapOpen("myheap", O_RDWR);
+  // restore table pointer from slot 0
+  PascalHashTable* table = OPHeapRestorePtr(heap, 0);
 
-void simple_object_database(char* filename)
-{
-  OPHeap* heap1, heap2;
+  uint64_t* val;
+  val = PHGet(table, "ABC", 4);
+  printf("ABC -> %" PRIu64 "\n", *val);
+  val = PHGet(table, "DEF", 4);
+  printf("DEF -> %" PRIu64 "\n", *val);
+  val = PHGet(table, "This is a long string", 22);
+  printf("This is a long string -> %" PRIu64 "\n", *val);
+  val = PHGet(table, "NAN", 4);
+  printf("Nan -> %p\n", val);
 
-  OPHeapNew(&heap1);
-
-  struct S1* s1 = (struct S1*)OPMalloc(heap1, sizeof(struct S1));
-  struct S2* s2 = (struct S2*)OPMalloc(heap1, sizeof(struct S2));
-
-  // object relationships in OPIC must convert to opref_t
-  s1->s2_ref = OPPtr2Ref(s2);
-
-  // opref_t can convert back to pointer via OPRef2Ptr
-  struct S2* s2_ptr = OPRef2Ptr(heap1, s1->s2ref);
-
-  // Serialize the heap to a file
-  OPHeapStorePtr(heap1, s1, 0);
-
-  fd = fopen(filename, "w");
-  OPHeapWrite(heap1, fd)
-  fclose(fd);
-  OPHeapDestroy(heap1);
-
-  // Deserialize the heap and restore the objects
-  fd = fopen(filename, "r");
-  OPHeapRead(&heap2, fd);
-  fclose(fd);
-
-  s1 = (struct S1*)OPHeapRestorePtr(heap2, 0);
-  s2 = s2_ptr = OPRef2Ptr(heap2, s1->s2_ref);
-  OPHeapDestroy(heap2);
+  OPHeapClose(heap);
+  return 0;
 }
 ```
 
@@ -70,11 +96,9 @@ DEPENDENCY
 ----------
 
 * C compiler with support of C11 atomics.
-  - gcc 4.9, gcc 5, gcc 6
+  - gcc 4.9, gcc 5, gcc 6, and above
   - TODO: figure out which versions of clang support C11 atomics.
 * [log4c (>= 1.2.4)](http://log4c.sourceforge.net)
-  - I guess 1.2.1 also works, but 1.2.4 was released since 2008. Getting
-  it on most distros shouldn't be hard.
 * [cmocka (>= 1.0.1)](https://cmocka.org)
   - Required for unit testing.
 * GNU Autotools for people who want to build from head
@@ -99,14 +123,24 @@ make
 sudo make install
 ```
 
+HOW DOES IT WORK?
+-----------------
+
+I wrote a initial draft to explain how it works. Check out my blog post:
+http://www.idryman.org/blog/2017/06/28/opic-a-memory-allocator-for-fast-serialization/
+
 DATA STRUCTURES INCLUDED
 ------------------------
 
-* RobinHoodHash, can be used as
+* OPHashTable. For fixed length key. Can be used as
   - HashMap
   - HashSet
   - HashMultimap
-  - TODO: document benchmark results
+
+* PascalHashTable. For length varying key. Can be used as
+  - HashMap
+  - HashSet
+  - HashMultimap
 
 * TODO (like a wishlist):
   - Integer DS which support predecessor quries

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ map the file into memory region. The data is not loaded into memory
 until the program access it. For writing, `msync()` is quite fast as
 well.
 
-SYNOPSIS --------
+SYNOPSIS
+--------
 
 Using OPIC we can quickly draft out a poor man's key value store.
 OPIC provides two types of hash table: `OPHashTable` for fixed length

--- a/README.md
+++ b/README.md
@@ -12,17 +12,15 @@ deserialization is simply a mmap syscall.
 
 
 OPIC is suitable for building database indexes, key-value store, or even search
-engines. At the moment of writing we provide a POC hash table to demonstrate how
+engines. At the moment of writing we provide a hash table to demonstrate how
 easy it is to build an embedded key-value store engine.
-
-TODO: link to post or tutorial for the hash table.
 
 SYNOPSIS
 --------
 
 ```c
-#include <stdio.h>
 #include "opic/op_malloc.h"
+#include "opic/hash/op_hash_table.h"
 
 struct S1
 {
@@ -37,7 +35,6 @@ struct S2
 void simple_object_database(char* filename)
 {
   OPHeap* heap1, heap2;
-  FILE* fd;
 
   OPHeapNew(&heap1);
 
@@ -52,6 +49,7 @@ void simple_object_database(char* filename)
 
   // Serialize the heap to a file
   OPHeapStorePtr(heap1, s1, 0);
+
   fd = fopen(filename, "w");
   OPHeapWrite(heap1, fd)
   fclose(fd);
@@ -101,13 +99,6 @@ make
 sudo make install
 ```
 
-User who runs OPIC on linux need to disable overcommit accounting.  This is
-because OPIC pre-allocates large memory in 64bit memory space.
-
-```bash
-sudo sysctl vm.overcommit_memory=1
-```
-
 DATA STRUCTURES INCLUDED
 ------------------------
 
@@ -154,17 +145,17 @@ Cityhash is included in this project. Here is the copyright statements for
 cityhash:
 
     Copyright (c) 2011 Google, Inc.
-    
+
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
     in the Software without restriction, including without limitation the rights
     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
     copies of the Software, and to permit persons to whom the Software is
     furnished to do so, subject to the following conditions:
-    
+
     The above copyright notice and this permission notice shall be included in
     all copies or substantial portions of the Software.
-    
+
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/benchmark/malloc/malloc_bench.c
+++ b/benchmark/malloc/malloc_bench.c
@@ -202,12 +202,13 @@ int main(int argc, char **argv)
     assert(desc.blk_array != NULL);
     memset(desc.blk_array, 0, num_blks * sizeof(unsigned char *));
 
-    assert(OPHeapNew(&heap));
+    heap = OPHeapOpenTmp();
+    assert(heap);
 
     start_bench(&desc);
     stop_bench(&desc);
 
-    OPHeapDestroy(heap);
+    OPHeapClose(heap);
     /*
 TODO: create a cross platform high resolution timer.
     struct timespec start, end;

--- a/benchmark/robin_hood/del_bench.c
+++ b/benchmark/robin_hood/del_bench.c
@@ -150,7 +150,7 @@ int main(int argc, char* argv[])
           break;
         }
     }
-  OPHeapNew(&heap);
+  heap = OPHeapOpenTmp();
   if (use_rhh)
     {
       OPHashTable* rhh;
@@ -370,7 +370,7 @@ int main(int argc, char* argv[])
         }
       TableDestroy(table);
     }
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 

--- a/benchmark/robin_hood/del_bench.c
+++ b/benchmark/robin_hood/del_bench.c
@@ -154,7 +154,7 @@ int main(int argc, char* argv[])
   if (use_rhh)
     {
       OPHashTable* rhh;
-      HTNew(heap, &rhh, num, load, 8, 8);
+      rhh = HTNew(heap, num, load, 8, 8);
 
       printf("iteration %d\n", 0);
       sprintf(fname, "%s_%02d", fname_base, 0);

--- a/benchmark/robin_hood/funnel_bench.c
+++ b/benchmark/robin_hood/funnel_bench.c
@@ -301,7 +301,7 @@ int main(int argc, char* argv[])
   num = 1UL << num_power;
   printf("running elements %" PRIu64 "\n", num);
 
-  op_assert(OPHeapNew(&heap), "Create OPHeap\n");
+  heap = OPHeapOpenTmp();
 
   for (int i = 0; i < repeat; i++)
     {
@@ -337,6 +337,7 @@ int main(int argc, char* argv[])
       rhh_destroy(rhh);
     }
   printf("objcnt: %d val_sum: %" PRIu64 "\n", objcnt, val_sum);
+  OPHeapClose(heap);
 
   return 0;
 }

--- a/benchmark/robin_hood/funnel_bench.c
+++ b/benchmark/robin_hood/funnel_bench.c
@@ -70,9 +70,6 @@ typedef uint64_t (*HashFunc)(void* key, void* context, OPHash hasher);
 typedef void (*RunKey)(int size, HashFunc hash_func,
                        void* context, OPHash hasher);
 
-typedef bool (*HTNew_t)(OPHeap* heap, void* rhh,
-                         uint64_t num_objects, double load,
-                         size_t keysize, size_t valsize);
 typedef void (*HTDestroy_t)(void* rhh);
 typedef void (*HTPrintStat_t)(void* rhh);
 
@@ -193,7 +190,6 @@ int main(int argc, char* argv[])
   bool print_stat = false;
   HTFunnel* funnel;
 
-  HTNew_t rhh_new = (HTNew_t)HTNew;
   HTDestroy_t rhh_destroy = (HTDestroy_t)HTDestroy;
   HashFunc rhh_put = HTFunnelInsertWrap;
   HashFunc rhh_get = HTFunnelGetWrap;
@@ -204,7 +200,7 @@ int main(int argc, char* argv[])
 
   num_power = 20;
 
-  while ((opt = getopt(argc, argv, "a:b:n:r:k:i:l:f:ph")) > -1)
+  while ((opt = getopt(argc, argv, "a:b:n:r:k:l:f:ph")) > -1)
     {
       switch (opt)
         {
@@ -243,23 +239,6 @@ int main(int argc, char* argv[])
             }
           else
             help(argv[0]);
-          break;
-        case 'i':
-          /* if (!strcmp("rhh", optarg)) */
-          /*   { */
-          /*     printf("Using official robin_hood\n"); */
-          /*   } */
-          /* else if (!strcmp("rhh_b_k_v", optarg)) */
-          /*   { */
-          /*     printf("Using rhh_b_k_v\n"); */
-          /*     rhh_new = (HTNew_t)HT_b_k_v_New; */
-          /*     rhh_destroy = (HTDestroy_t)HT_b_k_v_Destroy; */
-          /*     rhh_put = HT_b_k_v_PutWrap; */
-          /*     rhh_get = HT_b_k_v_GetWrap; */
-          /*     rhh_printstat = (HTPrintStat_t)HT_b_k_v_PrintStat; */
-          /*   } */
-          /* else */
-          /*   help(argv[0]); */
           break;
         case 'l':
           load = atof(optarg);
@@ -306,8 +285,7 @@ int main(int argc, char* argv[])
   for (int i = 0; i < repeat; i++)
     {
       printf("attempt %d\n", i + 1);
-      op_assert(rhh_new(heap, &rhh, num,
-                        load, k_len, 8), "Create OPHashTable\n");
+      rhh = HTNew(heap, num, load, k_len, 8);
 
       funnel = HTFunnelNewCustom(rhh, hasher, NULL,
                                   funnel_slotsize, funnel_partition_size);

--- a/benchmark/robin_hood/int_bench.c
+++ b/benchmark/robin_hood/int_bench.c
@@ -224,7 +224,7 @@ int main(int argc, char* argv[])
 
   printf("running elements %" PRIu64 "\n", num);
 
-  op_assert(OPHeapNew(&heap), "Create OPHeap\n");
+  heap = OPHeapOpenTmp();
 
   for (int i = 0; i < repeat; i++)
     {
@@ -265,6 +265,8 @@ int main(int argc, char* argv[])
     }
   if (stat_stream)
     fclose(stat_stream);
+
+  OPHeapClose(heap);
 
   return 0;
 }

--- a/benchmark/robin_hood/probe_bench.c
+++ b/benchmark/robin_hood/probe_bench.c
@@ -305,7 +305,7 @@ int main(int argc, char* argv[])
   num = 1UL << num_power;
   printf("running elements %" PRIu64 "\n", num);
 
-  op_assert(OPHeapNew(&heap), "Create OPHeap\n");
+  heap = OPHeapOpenTmp();
 
   for (int i = 0; i < repeat; i++)
     {
@@ -337,6 +337,7 @@ int main(int argc, char* argv[])
   if (stat_stream)
     fclose(stat_stream);
 
+  OPHeapClose(heap);
   return 0;
 }
 

--- a/benchmark/robin_hood/robin_bench.c
+++ b/benchmark/robin_hood/robin_bench.c
@@ -116,6 +116,15 @@ uint64_t farm(void* key, size_t size)
   return farmhash64(key, size);
 }
 
+bool RHHNewWrap(OPHeap* heap, void* rhh,
+                uint64_t num_objects, double load,
+                size_t keysize, size_t valsize)
+{
+  OPHashTable** table = rhh;
+  *table = HTNew(heap, num_objects, load, keysize, valsize);
+  return *table != NULL;
+}
+
 uint64_t RHHPutWrap(void* key, void* context, OPHash hash_impl)
 {
   static uint64_t val = 0;
@@ -195,7 +204,7 @@ int main(int argc, char* argv[])
   char* stat_header = "RHH";
   FILE* stat_stream = NULL;
 
-  RHHNew_t rhh_new = (RHHNew_t)HTNew;
+  RHHNew_t rhh_new = RHHNewWrap;
   RHHDestroy_t rhh_destroy = (RHHDestroy_t)HTDestroy;
   HashFunc rhh_put = RHHPutWrap;
   HashFunc rhh_get = RHHGetWrap;

--- a/benchmark/robin_hood/robin_bench.c
+++ b/benchmark/robin_hood/robin_bench.c
@@ -353,7 +353,7 @@ int main(int argc, char* argv[])
   num = 1UL << num_power;
   printf("running elements %" PRIu64 "\n", num);
 
-  op_assert(OPHeapNew(&heap), "Create OPHeap\n");
+  heap = OPHeapOpenTmp();
 
   for (int i = 0; i < repeat; i++)
     {
@@ -412,6 +412,7 @@ int main(int argc, char* argv[])
   if (stat_stream)
     fclose(stat_stream);
 
+  OPHeapClose(heap);
   return 0;
 }
 

--- a/benchmark/robin_hood/worst_case.c
+++ b/benchmark/robin_hood/worst_case.c
@@ -228,7 +228,7 @@ int main(int argc, char* argv[])
          num, percent);
   allkeys = malloc(k_len * num);
 
-  OPHeapNew(&heap);
+  heap = OPHeapOpenTmp();
 
   if (use_rhh)
     {
@@ -298,7 +298,7 @@ int main(int argc, char* argv[])
       printf("probe mean: %f\n", (float)probe_sum/(float)items);
     }
   printf("val_sum: %" PRIu64 "\n",  val_sum);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
   free(allkeys);
 }
 

--- a/benchmark/robin_hood/worst_case.c
+++ b/benchmark/robin_hood/worst_case.c
@@ -232,7 +232,7 @@ int main(int argc, char* argv[])
 
   if (use_rhh)
     {
-      HTNew(heap, &rhh, num, load, k_len, 8);
+      rhh = HTNew(heap, num, load, k_len, 8);
       key_func(num_power, HTPutWrap, rhh, hasher);
       allkeys_iter = allkeys;
       HTIterate(rhh, RecordHashKey, &allkeys_iter);

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([OPIC],[0.7.0])
+AC_INIT([OPIC],[0.8.0])
 
 AC_CONFIG_SRCDIR([README.md])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/opic/hash/op_hash_table.c
+++ b/opic/hash/op_hash_table.c
@@ -114,10 +114,11 @@ struct HTFunnel
 static inline
 uint64_t HTCapacityInternal(uint8_t capacity_clz, uint8_t capacity_ms4b);
 
-bool
-HTNew(OPHeap* heap, OPHashTable** table,
-      uint64_t num_objects, double load, size_t keysize, size_t valsize)
+OPHashTable*
+HTNew(OPHeap* heap, uint64_t num_objects, double load,
+      size_t keysize, size_t valsize)
 {
+  OPHashTable* table;
   uint64_t capacity;
   uint32_t capacity_clz, capacity_ms4b, capacity_msb;
   size_t bucket_size;
@@ -135,24 +136,24 @@ HTNew(OPHeap* heap, OPHashTable** table,
 
   bucket_size = keysize + valsize + 1;
 
-  *table = OPCalloc(heap, 1, sizeof(OPHashTable));
-  if (!*table)
-    return false;
+  table = OPCalloc(heap, 1, sizeof(OPHashTable));
+  if (!table)
+    return NULL;
   bucket_ptr = OPCalloc(heap, 1, bucket_size * capacity);
   if (!bucket_ptr)
     {
       OPDealloc(table);
-      return false;
+      return NULL;
     }
-  (*table)->bucket_ref = OPPtr2Ref(bucket_ptr);
-  (*table)->large_data_threshold = DEFAULT_LARGE_DATA_THRESHOLD;
-  (*table)->capacity_clz = capacity_clz;
-  (*table)->capacity_ms4b = capacity_ms4b;
-  (*table)->objcnt_high = (uint64_t)(capacity * load);
-  (*table)->objcnt_low = capacity * 2 / 10;
-  (*table)->keysize = keysize;
-  (*table)->valsize = valsize;
-  return true;
+  table->bucket_ref = OPPtr2Ref(bucket_ptr);
+  table->large_data_threshold = DEFAULT_LARGE_DATA_THRESHOLD;
+  table->capacity_clz = capacity_clz;
+  table->capacity_ms4b = capacity_ms4b;
+  table->objcnt_high = (uint64_t)(capacity * load);
+  table->objcnt_low = capacity * 2 / 10;
+  table->keysize = keysize;
+  table->valsize = valsize;
+  return table;
 }
 
 void

--- a/opic/hash/op_hash_table.h
+++ b/opic/hash/op_hash_table.h
@@ -70,18 +70,16 @@ typedef struct HTFunnel HTFunnel;
  * @brief Constructor for OPHashTable.
  *
  * @param heap OPHeap instance.
- * @param table_ref reference to the OPHashTable pointer for assigining
- * OPHashTable instance.
  * @param num_objects number of objects we decided to put in.
  * @param load (0.0-1.0) how full the hash table could be
  * before expansion.
  * @param keysize length of key measured in bytes. Cannot be zero.
  * @param valsize length of value measured in bytes. This vlaue
  * can be zero and the hash table would work like a hash set.
- * @return true when the allocation succeeded, false otherwise.
+ * @return OPHashTable instance if allocation succeeded, else return NULL.
  */
-bool HTNew(OPHeap* heap, OPHashTable** table_ref, uint64_t num_objects,
-           double load, size_t keysize, size_t valsize);
+OPHashTable* HTNew(OPHeap* heap, uint64_t num_objects,
+                   double load, size_t keysize, size_t valsize);
 
 /**
  * @relates OPHashTable

--- a/opic/hash/op_hash_table_test.c
+++ b/opic/hash/op_hash_table_test.c
@@ -92,11 +92,11 @@ test_HTNew(void** context)
 {
   OPHeap* heap;
   OPHashTable* table;
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(HTNew(heap, &table, TEST_OBJECTS,
                      0.95, sizeof(int), 0));
   HTDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -106,7 +106,7 @@ test_BasicInsert(void** context)
   OPHashTable* table;
 
   OP_LOG_INFO(logger, "Starting basic insert");
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(HTNew(heap, &table, 20,
                      0.80, sizeof(int), 0));
   OP_LOG_DEBUG(logger, "HT addr %p", table);
@@ -133,7 +133,7 @@ test_BasicInsert(void** context)
     }
 
   HTDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -143,7 +143,7 @@ test_BasicDelete(void** context)
   OPHashTable* table;
   int i;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(HTNew(heap, &table, TEST_OBJECTS,
                      0.95, sizeof(int), 0));
   for (i = 0; i < TEST_OBJECTS; i++)
@@ -166,7 +166,7 @@ test_BasicDelete(void** context)
   HTIterate(table, CountObjects, NULL);
   assert_int_equal(0, objcnt);
   HTDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -176,7 +176,7 @@ test_DistributionForUpdate(void** context)
   OPHashTable* table;
   int key;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(HTNew(heap, &table, TEST_OBJECTS,
                      0.70, sizeof(int), 0));
 
@@ -196,7 +196,7 @@ test_DistributionForUpdate(void** context)
     }
   HTPrintStat(table);
   HTDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -207,7 +207,7 @@ test_Upsert(void** context)
   int* val;
   bool is_duplicate;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(HTNew(heap, &table, 20,
                      0.7, sizeof(int), sizeof(int)));
 
@@ -225,7 +225,7 @@ test_Upsert(void** context)
       assert_int_equal(i, *val);
     }
   HTDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -235,7 +235,7 @@ test_BasicInsertSmall(void** context)
   OPHashTable* table;
 
   OP_LOG_INFO(logger, "Starting basic insert");
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(HTNew(heap, &table, 20,
                      0.80, sizeof(int), 0));
   OP_LOG_DEBUG(logger, "HT addr %p", table);
@@ -255,7 +255,7 @@ test_BasicInsertSmall(void** context)
       assert_null(HTGet(table, &i));
     }
   HTDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -265,7 +265,7 @@ test_BasicDeleteSmall(void** context)
   OPHashTable* table;
   int i;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(HTNew(heap, &table, SMALL_TEST_OBJECTS,
                      0.95, sizeof(int), 0));
   for (i = 0; i < SMALL_TEST_OBJECTS; i++)
@@ -288,7 +288,7 @@ test_BasicDeleteSmall(void** context)
   HTIterate(table, CountObjects, NULL);
   assert_int_equal(0, objcnt);
   HTDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -298,7 +298,7 @@ test_DistributionForUpdateSmall(void** context)
   OPHashTable* table;
   int key;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(HTNew(heap, &table, SMALL_TEST_OBJECTS,
                      0.70, sizeof(int), 0));
 
@@ -318,7 +318,7 @@ test_DistributionForUpdateSmall(void** context)
     }
   HTPrintStat(table);
   HTDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -329,7 +329,7 @@ test_UpsertSmall(void** context)
   int* val;
   bool is_duplicate;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(HTNew(heap, &table, 20,
                      0.7, sizeof(int), sizeof(int)));
 
@@ -356,7 +356,7 @@ test_FunnelInsert(void** context)
   HTFunnel* funnel;
 
   OP_LOG_INFO(logger, "Starting funnel insert");
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(HTNew(heap, &table, TEST_OBJECTS,
                      0.80, sizeof(int), 0));
   funnel = HTFunnelNew(table, NULL, 2048, 2048);
@@ -378,7 +378,7 @@ test_FunnelInsert(void** context)
       assert_int_equal(1, objmap[i]);
     }
   HTDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 void upsert_empty_bucket(void* key,
@@ -418,7 +418,7 @@ test_FunnelUpsert(void** context)
   OPHashTable* table;
   HTFunnel* funnel;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(HTNew(heap, &table, TEST_OBJECTS,
                      0.8, sizeof(int), sizeof(int)));
   funnel = HTFunnelNew(table, upsert_empty_bucket, 2048, 2048);
@@ -450,7 +450,7 @@ test_FunnelUpsert(void** context)
   HTFunnelUpsertFlush(funnel);
   HTFunnelDestroy(funnel);
   HTDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 void funnel_count_objects(void* key, void* value, void* ctx,
@@ -484,7 +484,7 @@ test_FunnelGet(void** context)
   OPHashTable* table;
   HTFunnel* funnel;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(HTNew(heap, &table, TEST_OBJECTS,
                      0.8, sizeof(int), sizeof(int)));
 
@@ -541,7 +541,7 @@ test_FunnelGet(void** context)
     }
 
   HTDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -551,7 +551,7 @@ test_FunnelDelete(void** context)
   OPHashTable* table;
   HTFunnel* funnel;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(HTNew(heap, &table, TEST_OBJECTS,
                      0.8, sizeof(int), sizeof(int)));
 
@@ -578,7 +578,7 @@ test_FunnelDelete(void** context)
   assert_int_equal(0, objcnt);
 
   HTDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 int

--- a/opic/hash/op_hash_table_test.c
+++ b/opic/hash/op_hash_table_test.c
@@ -93,8 +93,7 @@ test_HTNew(void** context)
   OPHeap* heap;
   OPHashTable* table;
   heap = OPHeapOpenTmp();
-  assert_true(HTNew(heap, &table, TEST_OBJECTS,
-                     0.95, sizeof(int), 0));
+  table = HTNew(heap, TEST_OBJECTS, 0.95, sizeof(int), 0);
   HTDestroy(table);
   OPHeapClose(heap);
 }
@@ -107,8 +106,7 @@ test_BasicInsert(void** context)
 
   OP_LOG_INFO(logger, "Starting basic insert");
   heap = OPHeapOpenTmp();
-  assert_true(HTNew(heap, &table, 20,
-                     0.80, sizeof(int), 0));
+  table = HTNew(heap, 20, 0.80, sizeof(int), 0);
   OP_LOG_DEBUG(logger, "HT addr %p", table);
   for (int i = 0; i < TEST_OBJECTS; i++)
     {
@@ -144,8 +142,7 @@ test_BasicDelete(void** context)
   int i;
 
   heap = OPHeapOpenTmp();
-  assert_true(HTNew(heap, &table, TEST_OBJECTS,
-                     0.95, sizeof(int), 0));
+  table = HTNew(heap,TEST_OBJECTS, 0.95, sizeof(int), 0);
   for (i = 0; i < TEST_OBJECTS; i++)
     {
       HTInsert(table, &i, NULL);
@@ -177,8 +174,7 @@ test_DistributionForUpdate(void** context)
   int key;
 
   heap = OPHeapOpenTmp();
-  assert_true(HTNew(heap, &table, TEST_OBJECTS,
-                     0.70, sizeof(int), 0));
+  table = HTNew(heap, TEST_OBJECTS, 0.70, sizeof(int), 0);
 
   for (int i = 0; i < TEST_OBJECTS; i++)
     {
@@ -208,8 +204,7 @@ test_Upsert(void** context)
   bool is_duplicate;
 
   heap = OPHeapOpenTmp();
-  assert_true(HTNew(heap, &table, 20,
-                     0.7, sizeof(int), sizeof(int)));
+  table = HTNew(heap, 20, 0.7, sizeof(int), sizeof(int));
 
   for (int i = 0; i < TEST_OBJECTS; i++)
     {
@@ -236,8 +231,7 @@ test_BasicInsertSmall(void** context)
 
   OP_LOG_INFO(logger, "Starting basic insert");
   heap = OPHeapOpenTmp();
-  assert_true(HTNew(heap, &table, 20,
-                     0.80, sizeof(int), 0));
+  table = HTNew(heap, 20, 0.80, sizeof(int), 0);
   OP_LOG_DEBUG(logger, "HT addr %p", table);
   for (int i = 0; i < SMALL_TEST_OBJECTS; i++)
     {
@@ -266,8 +260,7 @@ test_BasicDeleteSmall(void** context)
   int i;
 
   heap = OPHeapOpenTmp();
-  assert_true(HTNew(heap, &table, SMALL_TEST_OBJECTS,
-                     0.95, sizeof(int), 0));
+  table = HTNew(heap, SMALL_TEST_OBJECTS, 0.95, sizeof(int), 0);
   for (i = 0; i < SMALL_TEST_OBJECTS; i++)
     {
       HTInsert(table, &i, NULL);
@@ -299,8 +292,7 @@ test_DistributionForUpdateSmall(void** context)
   int key;
 
   heap = OPHeapOpenTmp();
-  assert_true(HTNew(heap, &table, SMALL_TEST_OBJECTS,
-                     0.70, sizeof(int), 0));
+  table = HTNew(heap, SMALL_TEST_OBJECTS, 0.70, sizeof(int), 0);
 
   for (int i = 0; i < SMALL_TEST_OBJECTS; i++)
     {
@@ -330,8 +322,7 @@ test_UpsertSmall(void** context)
   bool is_duplicate;
 
   heap = OPHeapOpenTmp();
-  assert_true(HTNew(heap, &table, 20,
-                     0.7, sizeof(int), sizeof(int)));
+  table = HTNew(heap, 20, 0.7, sizeof(int), sizeof(int));
 
   for (int i = 0; i < SMALL_TEST_OBJECTS; i++)
     {
@@ -357,8 +348,7 @@ test_FunnelInsert(void** context)
 
   OP_LOG_INFO(logger, "Starting funnel insert");
   heap = OPHeapOpenTmp();
-  assert_true(HTNew(heap, &table, TEST_OBJECTS,
-                     0.80, sizeof(int), 0));
+  table = HTNew(heap, TEST_OBJECTS, 0.80, sizeof(int), 0);
   funnel = HTFunnelNew(table, NULL, 2048, 2048);
   for (int i = 0; i < TEST_OBJECTS; i++)
     {
@@ -419,8 +409,7 @@ test_FunnelUpsert(void** context)
   HTFunnel* funnel;
 
   heap = OPHeapOpenTmp();
-  assert_true(HTNew(heap, &table, TEST_OBJECTS,
-                     0.8, sizeof(int), sizeof(int)));
+  table = HTNew(heap, TEST_OBJECTS, 0.8, sizeof(int), sizeof(int));
   funnel = HTFunnelNew(table, upsert_empty_bucket, 2048, 2048);
 
   for (int i = 0; i < TEST_OBJECTS; i++)
@@ -485,8 +474,7 @@ test_FunnelGet(void** context)
   HTFunnel* funnel;
 
   heap = OPHeapOpenTmp();
-  assert_true(HTNew(heap, &table, TEST_OBJECTS,
-                     0.8, sizeof(int), sizeof(int)));
+  table = HTNew(heap, TEST_OBJECTS, 0.8, sizeof(int), sizeof(int));
 
   for (int i = 0; i < TEST_OBJECTS; i++)
     {
@@ -552,8 +540,7 @@ test_FunnelDelete(void** context)
   HTFunnel* funnel;
 
   heap = OPHeapOpenTmp();
-  assert_true(HTNew(heap, &table, TEST_OBJECTS,
-                     0.8, sizeof(int), sizeof(int)));
+  table = HTNew(heap, TEST_OBJECTS, 0.8, sizeof(int), sizeof(int));
 
   for (int i = 0; i < TEST_OBJECTS; i++)
     {

--- a/opic/hash/pascal_hash_table.c
+++ b/opic/hash/pascal_hash_table.c
@@ -96,10 +96,11 @@ struct PascalHashTable
   opref_t bucket_ref;
 };
 
-bool PHNew(OPHeap* heap, PascalHashTable** table,
-           uint64_t num_objects, double load,
-           size_t key_inline_size, size_t valsize)
+PascalHashTable*
+PHNew(OPHeap* heap, uint64_t num_objects, double load,
+      size_t key_inline_size, size_t valsize)
 {
+  PascalHashTable* table;
   uint64_t capacity;
   uint32_t capacity_clz, capacity_ms4b, capacity_msb;
   size_t bucket_size;
@@ -117,24 +118,24 @@ bool PHNew(OPHeap* heap, PascalHashTable** table,
 
   bucket_size = sizeof(oplenref_t) + key_inline_size + valsize;
 
-  *table = OPCalloc(heap, 1, sizeof(PascalHashTable));
-  if (!*table)
-    return false;
+  table = OPCalloc(heap, 1, sizeof(PascalHashTable));
+  if (!table)
+    return NULL;
   bucket_ptr = OPCalloc(heap, 1, bucket_size * capacity);
   if (!bucket_ptr)
     {
       OPDealloc(table);
-      return false;
+      return NULL;
     }
-  (*table)->bucket_ref = OPPtr2Ref(bucket_ptr);
-  (*table)->large_data_threshold = DEFAULT_LARGE_DATA_THRESHOLD;
-  (*table)->capacity_clz = capacity_clz;
-  (*table)->capacity_ms4b = capacity_ms4b;
-  (*table)->objcnt_high = (uint64_t)(capacity * load);
-  (*table)->objcnt_low = capacity * 2 / 10;
-  (*table)->key_inline_size = key_inline_size;
-  (*table)->valsize = valsize;
-  return true;
+  table->bucket_ref = OPPtr2Ref(bucket_ptr);
+  table->large_data_threshold = DEFAULT_LARGE_DATA_THRESHOLD;
+  table->capacity_clz = capacity_clz;
+  table->capacity_ms4b = capacity_ms4b;
+  table->objcnt_high = (uint64_t)(capacity * load);
+  table->objcnt_low = capacity * 2 / 10;
+  table->key_inline_size = key_inline_size;
+  table->valsize = valsize;
+  return table;
 }
 
 void PHDestroy(PascalHashTable* table)

--- a/opic/hash/pascal_hash_table.h
+++ b/opic/hash/pascal_hash_table.h
@@ -48,8 +48,6 @@ typedef struct PascalHashTable PascalHashTable;
  * @brief Constructor for PascalHashTable.
  *
  * @param heap OPHeap instance.
- * @param rhh_ref reference to the PascalHashTable pointer for
- * assignging PascalHashTable instance.
  * @param num_objects number of object we decided to put in.
  * @param load (0.0-1.0) how full the table could be before expansion.
  * @param key_inline_size Size to store the key inline. If the key size
@@ -58,11 +56,10 @@ typedef struct PascalHashTable PascalHashTable;
  *   is always used.
  * @param valsize length of the value measured in bytes. This value
  * can be zero for hashset.
- * @return true when the allocation succeeded, false otherwise.
+ * @return PascalHashTable instance if allocation succeeded, else return NULL.
  */
-bool PHNew(OPHeap* heap, PascalHashTable** rhh_ref,
-           uint64_t num_objects, double load,
-           size_t key_inline_size, size_t valsize);
+PascalHashTable* PHNew(OPHeap* heap, uint64_t num_objects, double load,
+                       size_t key_inline_size, size_t valsize);
 
 /**
  * @relates PascalHashTable

--- a/opic/hash/pascal_hash_table_test.c
+++ b/opic/hash/pascal_hash_table_test.c
@@ -103,14 +103,14 @@ test_PHNew(void** context)
 {
   OPHeap* heap;
   PascalHashTable* table;
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(PHNew(heap, &table, TEST_OBJECTS,
                       0.95, 0, 0));
   PHDestroy(table);
   assert_true(PHNew(heap, &table, TEST_OBJECTS,
                       0.95, 10, 0));
   PHDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -121,7 +121,7 @@ test_BasicInsert(void** context)
   size_t keylen;
 
   OP_LOG_INFO(logger, "Starting basic insert");
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(PHNew(heap, &table, 20, 0.80, 0, 0));
   OP_LOG_DEBUG(logger, "PH addr %p", table);
 
@@ -143,7 +143,7 @@ test_BasicInsert(void** context)
       assert_non_null(PHGet(table, uuid, keylen));
     }
   PHDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -154,7 +154,7 @@ test_BasicInsertWithKeyInline(void** context)
   size_t keylen;
 
   OP_LOG_INFO(logger, "Starting basic insert");
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(PHNew(heap, &table, 20, 0.80, 8, 0));
   OP_LOG_DEBUG(logger, "PH addr %p", table);
 
@@ -176,7 +176,7 @@ test_BasicInsertWithKeyInline(void** context)
       assert_non_null(PHGet(table, uuid, keylen));
     }
   PHDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -186,7 +186,7 @@ test_BasicDelete(void** context)
   PascalHashTable* table;
   size_t keylen;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(PHNew(heap, &table, TEST_OBJECTS, 0.95, 0, 0));
   for (int i = 0; i < TEST_OBJECTS; i++)
     {
@@ -206,7 +206,7 @@ test_BasicDelete(void** context)
   PHIterate(table, CountObjects, NULL);
   assert_int_equal(0, objcnt);
   PHDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -216,7 +216,7 @@ test_BasicDeleteWithKeyInline(void** context)
   PascalHashTable* table;
   size_t keylen;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(PHNew(heap, &table, TEST_OBJECTS, 0.95, 8, 0));
   for (int i = 0; i < TEST_OBJECTS; i++)
     {
@@ -236,7 +236,7 @@ test_BasicDeleteWithKeyInline(void** context)
   PHIterate(table, CountObjects, NULL);
   assert_int_equal(0, objcnt);
   PHDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -246,7 +246,7 @@ test_DistributionForUpdate(void** context)
   PascalHashTable* table;
   size_t keylen;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(PHNew(heap, &table, TEST_OBJECTS,
                       0.70, 0, 0));
 
@@ -270,7 +270,7 @@ test_DistributionForUpdate(void** context)
     }
   PHPrintStat(table);
   PHDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -283,7 +283,7 @@ test_Upsert(void** context)
   bool is_duplicate;
 
   OP_LOG_INFO(logger, "Starting basic insert");
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   assert_true(PHNew(heap, &table, 20, 0.80, 0, sizeof(int)));
   OP_LOG_DEBUG(logger, "PH addr %p", table);
 
@@ -303,7 +303,7 @@ test_Upsert(void** context)
       assert_int_equal(i, *val);
     }
   PHDestroy(table);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 int

--- a/opic/hash/pascal_hash_table_test.c
+++ b/opic/hash/pascal_hash_table_test.c
@@ -104,11 +104,9 @@ test_PHNew(void** context)
   OPHeap* heap;
   PascalHashTable* table;
   heap = OPHeapOpenTmp();
-  assert_true(PHNew(heap, &table, TEST_OBJECTS,
-                      0.95, 0, 0));
+  table = PHNew(heap, TEST_OBJECTS, 0.95, 0, 0);
   PHDestroy(table);
-  assert_true(PHNew(heap, &table, TEST_OBJECTS,
-                      0.95, 10, 0));
+  table = PHNew(heap, TEST_OBJECTS, 0.95, 10, 0);
   PHDestroy(table);
   OPHeapClose(heap);
 }
@@ -122,7 +120,7 @@ test_BasicInsert(void** context)
 
   OP_LOG_INFO(logger, "Starting basic insert");
   heap = OPHeapOpenTmp();
-  assert_true(PHNew(heap, &table, 20, 0.80, 0, 0));
+  table = PHNew(heap, 20, 0.80, 0, 0);
   OP_LOG_DEBUG(logger, "PH addr %p", table);
 
   for (int i = 0; i < TEST_OBJECTS; i++)
@@ -155,7 +153,7 @@ test_BasicInsertWithKeyInline(void** context)
 
   OP_LOG_INFO(logger, "Starting basic insert");
   heap = OPHeapOpenTmp();
-  assert_true(PHNew(heap, &table, 20, 0.80, 8, 0));
+  table = PHNew(heap, 20, 0.80, 8, 0);
   OP_LOG_DEBUG(logger, "PH addr %p", table);
 
   for (int i = 0; i < TEST_OBJECTS; i++)
@@ -187,7 +185,7 @@ test_BasicDelete(void** context)
   size_t keylen;
 
   heap = OPHeapOpenTmp();
-  assert_true(PHNew(heap, &table, TEST_OBJECTS, 0.95, 0, 0));
+  table = PHNew(heap, TEST_OBJECTS, 0.95, 0, 0);
   for (int i = 0; i < TEST_OBJECTS; i++)
     {
       keylen = MutateUUID(i);
@@ -217,7 +215,7 @@ test_BasicDeleteWithKeyInline(void** context)
   size_t keylen;
 
   heap = OPHeapOpenTmp();
-  assert_true(PHNew(heap, &table, TEST_OBJECTS, 0.95, 8, 0));
+  table = PHNew(heap, TEST_OBJECTS, 0.95, 8, 0);
   for (int i = 0; i < TEST_OBJECTS; i++)
     {
       keylen = MutateUUID(i);
@@ -247,8 +245,7 @@ test_DistributionForUpdate(void** context)
   size_t keylen;
 
   heap = OPHeapOpenTmp();
-  assert_true(PHNew(heap, &table, TEST_OBJECTS,
-                      0.70, 0, 0));
+  table = PHNew(heap, TEST_OBJECTS, 0.70, 0, 0);
 
   for (int i = 0; i < TEST_OBJECTS; i++)
     {
@@ -284,7 +281,7 @@ test_Upsert(void** context)
 
   OP_LOG_INFO(logger, "Starting basic insert");
   heap = OPHeapOpenTmp();
-  assert_true(PHNew(heap, &table, 20, 0.80, 0, sizeof(int)));
+  table = PHNew(heap, 20, 0.80, 0, sizeof(int));
   OP_LOG_DEBUG(logger, "PH addr %p", table);
 
   for (int i = 0; i < TEST_OBJECTS; i++)

--- a/opic/malloc/Makefile.am
+++ b/opic/malloc/Makefile.am
@@ -9,6 +9,7 @@ check_PROGRAMS = lookup_helper_test init_helper_test allocator_test \
 
 lookup_helper_test_SOURCES = \
   ../common/op_log.c \
+  allocator.c \
   lookup_helper_test.c \
   lookup_helper.c \
   init_helper.c \
@@ -20,6 +21,7 @@ lookup_helper_test_LDFLAGS = -static
 
 init_helper_test_SOURCES = \
   ../common/op_log.c \
+  allocator.c \
   init_helper.c \
   init_helper_test.c \
   lookup_helper.c \

--- a/opic/malloc/Makefile.am
+++ b/opic/malloc/Makefile.am
@@ -9,7 +9,6 @@ check_PROGRAMS = lookup_helper_test init_helper_test allocator_test \
 
 lookup_helper_test_SOURCES = \
   ../common/op_log.c \
-  allocator.c \
   lookup_helper_test.c \
   lookup_helper.c \
   init_helper.c \
@@ -21,7 +20,6 @@ lookup_helper_test_LDFLAGS = -static
 
 init_helper_test_SOURCES = \
   ../common/op_log.c \
-  allocator.c \
   init_helper.c \
   init_helper_test.c \
   lookup_helper.c \

--- a/opic/malloc/allocator_test.c
+++ b/opic/malloc/allocator_test.c
@@ -97,24 +97,6 @@ test_OPHeapObtainHPage_FullSize(void** context)
   assert_memory_equal(test_bmap, heap->header_bmap, sizeof(test_bmap));
   assert_int_equal(0, heap->pcard);
 
-  memset(test_bmap, 0xFF, sizeof(test_bmap));
-
-  atomic_store(&heap->occupy_bmap[0], ~0UL);
-  atomic_store(&heap->header_bmap[0], ~0UL);
-
-  for (int i = 0; i < (HPAGE_BMAP_NUM - 1) * 64; i++)
-    {
-      hpage_base = heap_base + (i + 64) * HPAGE_SIZE;
-      assert_true(OPHeapObtainHPage(heap, &ctx));
-      assert_ptr_equal(hpage_base, ctx.hspan.hpage);
-      assert_int_equal(0, heap->pcard);
-    }
-  assert_memory_equal(test_bmap, heap->occupy_bmap, sizeof(test_bmap));
-  assert_memory_equal(test_bmap, heap->header_bmap, sizeof(test_bmap));
-
-  assert_false(OPHeapObtainHPage(heap, &ctx));
-  assert_int_equal(0, heap->pcard);
-
   OPHeapClose(heap);
 }
 
@@ -541,6 +523,9 @@ test_USpanObtainAddr(void** context)
 
   heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
+  // ensure we get mmap file enlarged
+  assert_true(OPHeapObtainHPage(heap, &ctx));
+  assert_true(OPHeapObtainHPage(heap, &ctx));
 
   /*
    * Object size: 16 bytes; (The smallest raw_type size we can alloc)
@@ -652,6 +637,9 @@ test_USpanObtainAddr_Large(void** context)
 
   heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
+  // ensure we get mmap file enlarged
+  assert_true(OPHeapObtainHPage(heap, &ctx));
+  assert_true(OPHeapObtainHPage(heap, &ctx));
 
   /*
    * Object size: 1024 bytes

--- a/opic/malloc/allocator_test.c
+++ b/opic/malloc/allocator_test.c
@@ -59,7 +59,6 @@
 #include "init_helper.h"
 #include "allocator.h"
 
-
 static void
 test_OPHeapObtainHPage_FullSize(void** context)
 {

--- a/opic/malloc/allocator_test.c
+++ b/opic/malloc/allocator_test.c
@@ -68,7 +68,7 @@ test_OPHeapObtainHPage_FullSize(void** context)
   uint64_t test_bmap[HPAGE_BMAP_NUM] = {};
   OPHeapCtx ctx;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
 
   // first hpage
@@ -115,7 +115,7 @@ test_OPHeapObtainHPage_FullSize(void** context)
   assert_false(OPHeapObtainHPage(heap, &ctx));
   assert_int_equal(0, heap->pcard);
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -127,7 +127,7 @@ test_OPHeapObtainHPage_SmallSize(void** context)
   uint64_t header_bmap[HPAGE_BMAP_NUM] = {};
   OPHeapCtx ctx;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
   heap->hpage_num = 16;
   OPHeapEmptiedBMaps(heap, heap->occupy_bmap, heap->header_bmap);
@@ -170,7 +170,7 @@ test_OPHeapObtainHPage_SmallSize(void** context)
   assert_int_equal(0, heap->pcard);
 
   heap->hpage_num = HPAGE_BMAP_NUM * 64;
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -182,7 +182,7 @@ test_OPHeapObtainHBlob_Small(void** context)
   uint64_t header_bmap[HPAGE_BMAP_NUM] = {};
   OPHeapCtx ctx;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
 
   // first hpage won't be alloc for hblob
@@ -250,7 +250,7 @@ test_OPHeapObtainHBlob_Small(void** context)
   assert_int_equal(0, heap->pcard);
 
   // TODO need to test out of space case..
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -262,7 +262,7 @@ test_OPHeapObtainHBlob_Large(void** context)
   uint64_t header_bmap[HPAGE_BMAP_NUM] = {};
   OPHeapCtx ctx;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
 
   // first hpage won't be alloc for hblob
@@ -309,7 +309,7 @@ test_OPHeapObtainHBlob_Large(void** context)
   assert_memory_equal(header_bmap, heap->header_bmap, sizeof(header_bmap));
   assert_int_equal(0, heap->pcard);
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -323,7 +323,7 @@ test_HPageObtainUSpan(void** context)
   uint64_t occupy_bmap[8] = {0};
   uint64_t header_bmap[8] = {0};
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
 
   assert_true(OPHeapObtainHPage(heap, &ctx));
@@ -430,7 +430,7 @@ test_HPageObtainUSpan(void** context)
   assert_memory_equal(occupy_bmap, hpage->occupy_bmap, sizeof(occupy_bmap));
   assert_memory_equal(header_bmap, hpage->header_bmap, sizeof(header_bmap));
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -444,7 +444,7 @@ test_HPageObtainSSpan(void** context)
   uint64_t occupy_bmap[8] = {0};
   uint64_t header_bmap[8] = {0};
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
 
   assert_true(OPHeapObtainHPage(heap, &ctx));
@@ -525,7 +525,7 @@ test_HPageObtainSSpan(void** context)
   assert_memory_equal(occupy_bmap, hpage->occupy_bmap, sizeof(occupy_bmap));
   assert_memory_equal(header_bmap, hpage->header_bmap, sizeof(header_bmap));
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -539,7 +539,7 @@ test_USpanObtainAddr(void** context)
   Magic umagic = {};
   int count;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
 
   /*
@@ -636,7 +636,7 @@ test_USpanObtainAddr(void** context)
   assert_int_equal(SPAN_DEQUEUED, uspan->state);
   assert_ptr_equal(NULL, ctx.uqueue->uspan);
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -650,7 +650,7 @@ test_USpanObtainAddr_Large(void** context)
   Magic umagic = {};
   int count;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
 
   /*
@@ -715,7 +715,7 @@ test_USpanObtainAddr_Large(void** context)
   assert_int_equal(SPAN_DEQUEUED, uspan->state);
   assert_ptr_equal(NULL, ctx.uqueue->uspan);
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -723,12 +723,12 @@ test_DispatchHPageForSSpan(void** context)
 {
   OPHeap* heap;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
 
   // TODO: configure different kind of init state
   // run dispatch and see if the end state is expected
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 int

--- a/opic/malloc/deallocator_test.c
+++ b/opic/malloc/deallocator_test.c
@@ -60,6 +60,9 @@
 #include "allocator.h"
 #include "deallocator.h"
 
+extern void
+OPHeapCheckExpandSize(OPHeap* heap, size_t size);
+
 static void
 test_OPHeapReleaseHSpan_1Page(void** context)
 {
@@ -71,6 +74,8 @@ test_OPHeapReleaseHSpan_1Page(void** context)
   Magic raw_hpage_magic = {}, hblob_magic = {};
 
   heap = OPHeapOpenTmp();
+  OPHeapCheckExpandSize(heap, 68 * HPAGE_SIZE);
+
   heap_base = (uintptr_t)heap;
 
   occupy_bmap[0] = 0x0F;
@@ -172,6 +177,7 @@ test_OPHeapReleaseHSpan_smallHBlob(void** context)
   HugeSpanPtr hspan[4];
 
   heap = OPHeapOpenTmp();
+  OPHeapCheckExpandSize(heap, 97 * HPAGE_SIZE);
   heap_base = (uintptr_t)heap;
 
   //                                    7654321076543210
@@ -242,6 +248,7 @@ test_OPHeapReleaseHSpan_lageHBlob(void** context)
   HugeSpanPtr hspan[4];
 
   heap = OPHeapOpenTmp();
+  OPHeapCheckExpandSize(heap, 256 * HPAGE_SIZE);
   heap_base = (uintptr_t)heap;
 
   //                                    7654321076543210
@@ -337,6 +344,7 @@ test_HPageReleaseSSpan(void** context)
   uint64_t header_bmap[8] = {0};
 
   heap = OPHeapOpenTmp();
+  OPHeapCheckExpandSize(heap, 4 * HPAGE_SIZE);
   heap_base = (uintptr_t)heap;
   atomic_store(&heap->occupy_bmap[0], 0x07);
   atomic_store(&heap->header_bmap[0], 0x07);
@@ -454,6 +462,7 @@ test_USpanReleaseAddr(void** context)
   OPHeapCtx ctx;
 
   heap = OPHeapOpenTmp();
+  OPHeapCheckExpandSize(heap, 4 * HPAGE_SIZE);
   heap_base = (uintptr_t)heap;
   atomic_store(&heap->occupy_bmap[0], 0x02UL);
   atomic_store(&heap->header_bmap[0], 0x02UL);

--- a/opic/malloc/deallocator_test.c
+++ b/opic/malloc/deallocator_test.c
@@ -70,7 +70,7 @@ test_OPHeapReleaseHSpan_1Page(void** context)
   HugeSpanPtr hspan[8];
   Magic raw_hpage_magic = {}, hblob_magic = {};
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
 
   occupy_bmap[0] = 0x0F;
@@ -159,7 +159,7 @@ test_OPHeapReleaseHSpan_1Page(void** context)
   assert_memory_equal(header_bmap, heap->header_bmap, sizeof(header_bmap));
   assert_int_equal(0, heap->pcard);
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -171,7 +171,7 @@ test_OPHeapReleaseHSpan_smallHBlob(void** context)
   uint64_t header_bmap[HPAGE_BMAP_NUM] = {};
   HugeSpanPtr hspan[4];
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
 
   //                                    7654321076543210
@@ -229,7 +229,7 @@ test_OPHeapReleaseHSpan_smallHBlob(void** context)
   assert_memory_equal(header_bmap, heap->header_bmap, sizeof(header_bmap));
   assert_int_equal(0, heap->pcard);
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -241,7 +241,7 @@ test_OPHeapReleaseHSpan_lageHBlob(void** context)
   uint64_t header_bmap[HPAGE_BMAP_NUM] = {};
   HugeSpanPtr hspan[4];
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
 
   //                                    7654321076543210
@@ -319,7 +319,7 @@ test_OPHeapReleaseHSpan_lageHBlob(void** context)
   assert_memory_equal(header_bmap, heap->header_bmap, sizeof(header_bmap));
   assert_int_equal(0, heap->pcard);
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -336,7 +336,7 @@ test_HPageReleaseSSpan(void** context)
   uint64_t occupy_bmap[8] = {0};
   uint64_t header_bmap[8] = {0};
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
   atomic_store(&heap->occupy_bmap[0], 0x07);
   atomic_store(&heap->header_bmap[0], 0x07);
@@ -434,7 +434,7 @@ test_HPageReleaseSSpan(void** context)
   assert_int_equal(0x02UL, heap->occupy_bmap[0]);
   assert_int_equal(0x02UL, heap->header_bmap[0]);
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -453,7 +453,7 @@ test_USpanReleaseAddr(void** context)
   void* addr2;
   OPHeapCtx ctx;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
   atomic_store(&heap->occupy_bmap[0], 0x02UL);
   atomic_store(&heap->header_bmap[0], 0x02UL);
@@ -507,7 +507,7 @@ test_USpanReleaseAddr(void** context)
   assert_int_equal(0x04UL, hpage->occupy_bmap[1]);
   assert_int_equal(0x04UL, hpage->header_bmap[1]);
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 int

--- a/opic/malloc/init_helper_test.c
+++ b/opic/malloc/init_helper_test.c
@@ -81,7 +81,7 @@ test_HPageInit(void** context)
   uint64_t occupy_bmap[8] = {0};
   uint64_t header_bmap[8] = {0};
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
   magic.raw_hpage.pattern = RAW_HPAGE_PATTERN;
   ctx.hspan.hpage = &heap->hpage;
@@ -111,7 +111,7 @@ test_HPageInit(void** context)
   assert_memory_equal(occupy_bmap, hpage->occupy_bmap, 8 * sizeof(uint64_t));
   assert_memory_equal(header_bmap, hpage->header_bmap, 8 * sizeof(uint64_t));
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -125,7 +125,7 @@ test_USpanInit_RawTypeSmall(void** context)
   uint64_t* bmap;
   uint64_t test_bmap[4] = {0};
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
   ctx.sspan.uintptr = heap_base + HPAGE_SIZE + SPAGE_SIZE;
   uspan = ctx.sspan.uspan;
@@ -181,7 +181,7 @@ test_USpanInit_RawTypeSmall(void** context)
   //               7654321076543210
   test_bmap[2] = 0xFFFFFC0000000000UL;
   assert_memory_equal(test_bmap, bmap, 3 * sizeof(uint64_t));
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -195,7 +195,7 @@ test_USpanInit_RawTypeSmall_FstPage(void** context)
   uint64_t* bmap;
   uint64_t test_bmap[8] = {0};
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
   ctx.sspan.uintptr = heap_base + HPAGE_SIZE + sizeof(HugePage);
   uspan = ctx.sspan.uspan;
@@ -253,7 +253,7 @@ test_USpanInit_RawTypeSmall_FstPage(void** context)
   //               7654321076543210
   test_bmap[2] = 0xFFFFFC0000000000UL;
   assert_memory_equal(test_bmap, bmap, 3 * sizeof(uint64_t));
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 
@@ -268,7 +268,7 @@ test_USpanInit_RawTypeLarge(void** context)
   uint64_t* bmap;
   uint64_t test_bmap[8] = {0};
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
   ctx.sspan.uintptr = heap_base + HPAGE_SIZE + SPAGE_SIZE;
   uspan = ctx.sspan.uspan;
@@ -325,7 +325,7 @@ test_USpanInit_RawTypeLarge(void** context)
   test_bmap[0] = 0xFFFFFFFF00000001UL;
   assert_memory_equal(test_bmap, bmap, 1 * sizeof(uint64_t));
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -334,7 +334,7 @@ test_OPHeapEmptiedBMaps(void** context)
   OPHeap* heap;
   uint64_t test_bmap[HPAGE_BMAP_NUM] = {0};
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   OPHeapEmptiedBMaps(heap, heap->occupy_bmap, heap->header_bmap);
   assert_memory_equal(test_bmap, heap->occupy_bmap,
                       HPAGE_BMAP_NUM * sizeof(uint64_t));
@@ -355,7 +355,7 @@ test_OPHeapEmptiedBMaps(void** context)
   assert_memory_equal(test_bmap, heap->occupy_bmap,
                       HPAGE_BMAP_NUM * sizeof(uint64_t));
   heap->hpage_num = HPAGE_BMAP_NUM * 64;
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 int

--- a/opic/malloc/init_helper_test.c
+++ b/opic/malloc/init_helper_test.c
@@ -58,8 +58,8 @@
 #include "lookup_helper.h"
 #include "init_helper.h"
 
-extern bool
-OPHeapObtainHPage(OPHeap* heap, OPHeapCtx* ctx);
+extern void
+OPHeapCheckExpandSize(OPHeap* heap, size_t size);
 
 static void
 test_Sizes(void** context)
@@ -85,8 +85,6 @@ test_HPageInit(void** context)
   uint64_t header_bmap[8] = {0};
 
   heap = OPHeapOpenTmp();
-  // ensure we get mmap file enlarged
-  assert_true(OPHeapObtainHPage(heap, &ctx));
   heap_base = (uintptr_t)heap;
   magic.raw_hpage.pattern = RAW_HPAGE_PATTERN;
   ctx.hspan.hpage = &heap->hpage;
@@ -106,7 +104,7 @@ test_HPageInit(void** context)
   assert_memory_equal(occupy_bmap, hpage->occupy_bmap, 8 * sizeof(uint64_t));
   assert_memory_equal(header_bmap, hpage->header_bmap, 8 * sizeof(uint64_t));
 
-  assert_true(OPHeapObtainHPage(heap, &ctx));
+  OPHeapCheckExpandSize(heap, 2 * HPAGE_SIZE);
   ctx.hspan.uintptr = heap_base + HPAGE_SIZE;
   hpage = ctx.hspan.hpage;
   HPageInit(hpage, magic);
@@ -133,8 +131,7 @@ test_USpanInit_RawTypeSmall(void** context)
 
   heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
-  assert_true(OPHeapObtainHPage(heap, &ctx));
-  assert_true(OPHeapObtainHPage(heap, &ctx));
+  OPHeapCheckExpandSize(heap, 2 * HPAGE_SIZE);
   ctx.sspan.uintptr = heap_base + HPAGE_SIZE + SPAGE_SIZE;
   uspan = ctx.sspan.uspan;
   bmap = (uint64_t*)(ctx.sspan.uintptr + sizeof(UnarySpan));
@@ -205,8 +202,7 @@ test_USpanInit_RawTypeSmall_FstPage(void** context)
 
   heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
-  assert_true(OPHeapObtainHPage(heap, &ctx));
-  assert_true(OPHeapObtainHPage(heap, &ctx));
+  OPHeapCheckExpandSize(heap, 2 * HPAGE_SIZE);
   ctx.sspan.uintptr = heap_base + HPAGE_SIZE + sizeof(HugePage);
   uspan = ctx.sspan.uspan;
   bmap = (uint64_t*)(ctx.sspan.uintptr + sizeof(UnarySpan));
@@ -280,8 +276,7 @@ test_USpanInit_RawTypeLarge(void** context)
 
   heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
-  assert_true(OPHeapObtainHPage(heap, &ctx));
-  assert_true(OPHeapObtainHPage(heap, &ctx));
+  OPHeapCheckExpandSize(heap, 2 * HPAGE_SIZE);
   ctx.sspan.uintptr = heap_base + HPAGE_SIZE + SPAGE_SIZE;
   uspan = ctx.sspan.uspan;
   bmap = (uint64_t*)(ctx.sspan.uintptr + sizeof(UnarySpan));

--- a/opic/malloc/lookup_helper_test.c
+++ b/opic/malloc/lookup_helper_test.c
@@ -57,6 +57,9 @@
 #include "lookup_helper.h"
 #include "init_helper.h"
 
+extern bool
+OPHeapObtainHPage(OPHeap* heap, OPHeapCtx* ctx);
+
 static void
 test_ObtainOPHeap(void** state)
 {
@@ -255,7 +258,12 @@ test_HPageObtainSmallSpanPtr(void** context)
   uintptr_t heap_base, hpage_base,
     first_uspan, isolated_uspan, cross_bmap_uspan;
 
+  OPHeapCtx ctx;
+
   heap = OPHeapOpenTmp();
+  assert_true(OPHeapObtainHPage(heap, &ctx));
+  assert_true(OPHeapObtainHPage(heap, &ctx));
+
   heap_base = (uintptr_t)heap;
   hpage_base = heap_base + HPAGE_SIZE;
   hpage = (HugePage*)hpage_base;
@@ -378,8 +386,11 @@ test_ObtainUSpanQueue(void** state)
   UnarySpan* uspan;
   Magic* magic;
   uintptr_t uspan_base;
+  OPHeapCtx ctx;
 
   heap = OPHeapOpenTmp();
+  assert_true(OPHeapObtainHPage(heap, &ctx));
+  assert_true(OPHeapObtainHPage(heap, &ctx));
 
   uspan_base = (uintptr_t)heap + HPAGE_SIZE + SPAGE_SIZE;
   magic = (Magic*)uspan_base;
@@ -419,8 +430,11 @@ test_ObtainHPageQueue(void** state)
   HugePage* hpage;
   Magic* magic;
   uintptr_t hpage_base;
+  OPHeapCtx ctx;
 
   heap = OPHeapOpenTmp();
+  assert_true(OPHeapObtainHPage(heap, &ctx));
+  assert_true(OPHeapObtainHPage(heap, &ctx));
 
   hpage_base = (uintptr_t)heap + HPAGE_SIZE;
   magic = (Magic*)hpage_base;

--- a/opic/malloc/lookup_helper_test.c
+++ b/opic/malloc/lookup_helper_test.c
@@ -63,7 +63,7 @@ test_ObtainOPHeap(void** state)
   uintptr_t base, header, inner, boundary, out_of_reach;
   OPHeap* heap;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
 
   base = (uintptr_t)heap;
   header = (uintptr_t)&heap->hpage;
@@ -77,7 +77,7 @@ test_ObtainOPHeap(void** state)
   assert_ptr_equal(heap, ObtainOPHeap((void*)boundary));
   assert_ptr_not_equal(heap, ObtainOPHeap((void*)out_of_reach));
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -86,7 +86,7 @@ test_ObtainHPage(void** state)
   uintptr_t heap_base, first_hpage, second_hpage;
   OPHeap* heap;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
 
   heap_base = (uintptr_t)heap;
   first_hpage = (uintptr_t)&heap->hpage;
@@ -117,7 +117,7 @@ test_ObtainHPage(void** state)
      ObtainHPage((void*)(heap_base + HPAGE_SIZE*2 - 1)));
   assert_ptr_equal(second_hpage, ObtainHPage((void*)second_hpage));
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -126,7 +126,7 @@ test_ObtainHugeSpanPtr_firstBMap(void** state)
   OPHeap* heap;
   uintptr_t heap_base, first_hpage, second_hpage, isolated_hpage, hblob;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
 
   // test first hpage
   first_hpage = (uintptr_t)&heap->hpage;
@@ -203,7 +203,7 @@ test_ObtainHugeSpanPtr_firstBMap(void** state)
      ObtainHugeSpanPtr((void*)(heap_base + 20 * HPAGE_SIZE - 1))
      .hpage);
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -212,7 +212,7 @@ test_ObtainHugeSpanPtr_crossBMap(void** state)
   OPHeap* heap;
   uintptr_t heap_base, hblob;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
 
   heap_base = (uintptr_t)heap;
   hblob = heap_base + 4 * HPAGE_SIZE;
@@ -244,7 +244,7 @@ test_ObtainHugeSpanPtr_crossBMap(void** state)
     (hblob,
      ObtainHugeSpanPtr((void*)(heap_base + 4 * 64 * HPAGE_SIZE))
      .hpage);
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -255,7 +255,7 @@ test_HPageObtainSmallSpanPtr(void** context)
   uintptr_t heap_base, hpage_base,
     first_uspan, isolated_uspan, cross_bmap_uspan;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
   hpage_base = heap_base + HPAGE_SIZE;
   hpage = (HugePage*)hpage_base;
@@ -327,7 +327,7 @@ test_HPageObtainSmallSpanPtr(void** context)
       (void*)(hpage_base + SPAGE_SIZE * 64 * 3 - 1))
      .uspan);
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -337,7 +337,7 @@ test_HPageObtainSmallSpanPtr_firstHPage(void** context)
   HugePage* hpage;
   uintptr_t heap_base, cross_bmap_uspan;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
   heap_base = (uintptr_t)heap;
 
   atomic_store(&heap->occupy_bmap[0], 0x01);
@@ -368,7 +368,7 @@ test_HPageObtainSmallSpanPtr_firstHPage(void** context)
       (void*)(heap_base + SPAGE_SIZE * 64 * 3 - 1))
      .uspan);
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -379,7 +379,7 @@ test_ObtainUSpanQueue(void** state)
   Magic* magic;
   uintptr_t uspan_base;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
 
   uspan_base = (uintptr_t)heap + HPAGE_SIZE + SPAGE_SIZE;
   magic = (Magic*)uspan_base;
@@ -409,7 +409,7 @@ test_ObtainUSpanQueue(void** state)
   assert_ptr_equal(&heap->raw_type.large_uspan_queue[2],
                    ObtainUSpanQueue(uspan));
 
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 static void
@@ -420,7 +420,7 @@ test_ObtainHPageQueue(void** state)
   Magic* magic;
   uintptr_t hpage_base;
 
-  assert_true(OPHeapNew(&heap));
+  heap = OPHeapOpenTmp();
 
   hpage_base = (uintptr_t)heap + HPAGE_SIZE;
   magic = (Magic*)hpage_base;
@@ -429,7 +429,7 @@ test_ObtainHPageQueue(void** state)
   magic->raw_hpage.pattern = RAW_HPAGE_PATTERN;
   assert_ptr_equal(&heap->raw_type.hpage_queue,
                    ObtainHPageQueue(hpage));
-  OPHeapDestroy(heap);
+  OPHeapClose(heap);
 }
 
 int

--- a/opic/malloc/lookup_helper_test.c
+++ b/opic/malloc/lookup_helper_test.c
@@ -57,8 +57,8 @@
 #include "lookup_helper.h"
 #include "init_helper.h"
 
-extern bool
-OPHeapObtainHPage(OPHeap* heap, OPHeapCtx* ctx);
+extern void
+OPHeapCheckExpandSize(OPHeap* heap, size_t size);
 
 static void
 test_ObtainOPHeap(void** state)
@@ -258,11 +258,8 @@ test_HPageObtainSmallSpanPtr(void** context)
   uintptr_t heap_base, hpage_base,
     first_uspan, isolated_uspan, cross_bmap_uspan;
 
-  OPHeapCtx ctx;
-
   heap = OPHeapOpenTmp();
-  assert_true(OPHeapObtainHPage(heap, &ctx));
-  assert_true(OPHeapObtainHPage(heap, &ctx));
+  OPHeapCheckExpandSize(heap, 2 * HPAGE_SIZE);
 
   heap_base = (uintptr_t)heap;
   hpage_base = heap_base + HPAGE_SIZE;
@@ -386,11 +383,9 @@ test_ObtainUSpanQueue(void** state)
   UnarySpan* uspan;
   Magic* magic;
   uintptr_t uspan_base;
-  OPHeapCtx ctx;
 
   heap = OPHeapOpenTmp();
-  assert_true(OPHeapObtainHPage(heap, &ctx));
-  assert_true(OPHeapObtainHPage(heap, &ctx));
+  OPHeapCheckExpandSize(heap, 2 * HPAGE_SIZE);
 
   uspan_base = (uintptr_t)heap + HPAGE_SIZE + SPAGE_SIZE;
   magic = (Magic*)uspan_base;
@@ -430,11 +425,9 @@ test_ObtainHPageQueue(void** state)
   HugePage* hpage;
   Magic* magic;
   uintptr_t hpage_base;
-  OPHeapCtx ctx;
 
   heap = OPHeapOpenTmp();
-  assert_true(OPHeapObtainHPage(heap, &ctx));
-  assert_true(OPHeapObtainHPage(heap, &ctx));
+  OPHeapCheckExpandSize(heap, 2 * HPAGE_SIZE);
 
   hpage_base = (uintptr_t)heap + HPAGE_SIZE;
   magic = (Magic*)hpage_base;

--- a/opic/malloc/objdef.h
+++ b/opic/malloc/objdef.h
@@ -172,7 +172,8 @@ struct OPHeap
 {
   uint32_t version;
   a_int16_t pcard;
-  uint16_t hpage_num;
+  uint16_t hpage_num;   // Deprecated. We now use file size to determine
+                        // how many huge pages we use.
   opref_t root_ptrs[8];
   a_uint64_t occupy_bmap[HPAGE_BMAP_NUM];
   a_uint64_t header_bmap[HPAGE_BMAP_NUM];

--- a/opic/malloc/op_malloc.c
+++ b/opic/malloc/op_malloc.c
@@ -50,6 +50,7 @@
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <pthread.h>
 #include <errno.h>
 #include "opic/op_malloc.h"
 #include "opic/common/op_assert.h"
@@ -67,6 +68,8 @@
 
 OP_LOGGER_FACTORY(logger, "opic.malloc.op_malloc");
 
+static pthread_mutex_t op_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 struct HeapFdEntry
 {
   uintptr_t heap;
@@ -76,7 +79,7 @@ struct HeapFdEntry
 #define FDMAP_SIZE (1ULL<<12)
 static struct HeapFdEntry heap_fd_map[FDMAP_SIZE];
 
-int OPHeapGetFD(OPHeap* heap)
+static int OPHeapGetFD(OPHeap* heap)
 {
   uintptr_t uint_heap, idx_iter, idx, mask;
   uint_heap = (uintptr_t)heap;
@@ -97,7 +100,7 @@ int OPHeapGetFD(OPHeap* heap)
   return -1;
 }
 
-void OPHeapPutFD(OPHeap* heap, int fd)
+static void OPHeapPutFD(OPHeap* heap, int fd)
 {
   uintptr_t uint_heap, idx_iter, idx, mask;
   uint_heap = (uintptr_t)heap;
@@ -120,7 +123,7 @@ void OPHeapPutFD(OPHeap* heap, int fd)
     }
 }
 
-void OPHeapDelFD(OPHeap* heap)
+static void OPHeapDelFD(OPHeap* heap)
 {
   uintptr_t uint_heap, idx_iter, idx, mask;
   int fd;
@@ -148,17 +151,7 @@ void OPHeapDelFD(OPHeap* heap)
   return;
 }
 
-void OPHeapFSync(OPHeap* heap)
-{
-  int fd;
-  fd = OPHeapGetFD(heap);
-  op_assert(fd != -1,
-            "All OPHeap should have a matching fd. (fd=0 means on swap)\n");
-  if (fd)
-    fsync(fd);
-}
-
-off_t GetFDSize(int fd)
+static off_t GetFDSize(int fd)
 {
   struct stat heap_stat;
   if (fstat(fd, &heap_stat) == -1)
@@ -168,6 +161,64 @@ off_t GetFDSize(int fd)
       return ~0ULL;
     }
   return heap_stat.st_size;
+}
+
+void OPHeapMSync(OPHeap* heap)
+{
+  int fd;
+  off_t heap_size;
+  pthread_mutex_lock(&op_mutex);
+
+  fd = OPHeapGetFD(heap);
+  op_assert(fd != -1,
+            "All OPHeap should have a matching fd.\n");
+  heap_size = GetFDSize(fd);
+  if (!msync(heap, (size_t)heap_size, MS_SYNC))
+    {
+      OP_LOG_ERROR(logger, "msync on %p failed: %s",
+                   heap, strerror(errno));
+    }
+
+  pthread_mutex_unlock(&op_mutex);
+}
+
+
+void OPHeapCheckExpandSize(OPHeap* heap, size_t size)
+{
+  int heap_fd;
+  off_t heap_size, expand_boundary;
+  uintptr_t heap_base;
+
+  pthread_mutex_lock(&op_mutex);
+
+  heap_fd = OPHeapGetFD(heap);
+  heap_size = GetFDSize(heap_fd);
+  expand_boundary = (off_t)size;
+  heap_base = (uintptr_t)heap;
+
+  if (heap_size < expand_boundary)
+    {
+      OP_LOG_DEBUG(logger,
+                   "Expanding OPHeap %p size to %" PRIx64,
+                   heap, (uint64_t)expand_boundary);
+      if (ftruncate(heap_fd, expand_boundary) == -1)
+        {
+          OP_LOG_FATAL(logger, "Expanding fd %d failed. %s",
+                       heap_fd, strerror(errno));
+          op_assert(0, "Fatal error");
+        }
+      if (mmap((void*)(heap_base + heap_size),
+               expand_boundary - heap_size,
+               PROT_READ | PROT_WRITE,
+               MAP_FILE | MAP_SHARED | MAP_FIXED,
+               heap_fd, heap_size) == MAP_FAILED)
+        {
+          OP_LOG_FATAL(logger, "Expand OPHeap %p failed. %s",
+                       heap, strerror(errno));
+          op_assert(0, "Fatal error");
+        }
+    }
+  pthread_mutex_unlock(&op_mutex);
 }
 
 static inline
@@ -252,16 +303,20 @@ OPHeap* OPHeapOpen(const char *path, int flags)
 {
   OPHeap* heap;
   int fd;
+  pthread_mutex_lock(&op_mutex);
+
   fd = open(path, flags);
   if (fd == -1)
     {
       OP_LOG_ERROR(logger, "Failed to open %s. %s",
                    path, strerror(errno));
+      pthread_mutex_unlock(&op_mutex);
       return NULL;
     }
   heap = OPHeapOpenInternal(fd);
   if (heap)
     OPHeapPutFD(heap, fd);
+  pthread_mutex_unlock(&op_mutex);
   return heap;
 }
 
@@ -269,25 +324,33 @@ OPHeap* OPHeapOpenTmp()
 {
   OPHeap* heap;
   int fd;
-  FILE* pfile = tmpfile();
+  FILE* pfile;
+  pthread_mutex_lock(&op_mutex);
+
+  pfile = tmpfile();
   if (pfile == NULL)
     {
       OP_LOG_ERROR(logger, "Failed to create tmp file: %s",
                    strerror(errno));
+      pthread_mutex_unlock(&op_mutex);
       return NULL;
     }
   fd = fileno(pfile);
   heap = OPHeapOpenInternal(fd);
   if (heap)
     OPHeapPutFD(heap, fd);
+  pthread_mutex_unlock(&op_mutex);
   return heap;
 }
 
 void OPHeapClose(OPHeap* heap)
 {
-  OPHeapFSync(heap);
+  OPHeapMSync(heap);
+
+  pthread_mutex_lock(&op_mutex);
   OPHeapDelFD(heap);
   munmap(heap, OPHEAP_SIZE);
+  pthread_mutex_unlock(&op_mutex);
 }
 
 

--- a/opic/malloc/op_malloc.c
+++ b/opic/malloc/op_malloc.c
@@ -123,6 +123,7 @@ void OPHeapPutFD(OPHeap* heap, int fd)
 void OPHeapDelFD(OPHeap* heap)
 {
   uintptr_t uint_heap, idx_iter, idx, mask;
+  int fd;
   uint_heap = (uintptr_t)heap;
   idx_iter = uint_heap >> HPAGE_BITS;
   mask = FDMAP_SIZE - 1;
@@ -136,6 +137,7 @@ void OPHeapDelFD(OPHeap* heap)
         return;
       if (heap_fd_map[idx].heap == uint_heap)
         {
+          fd = heap_fd_map[idx].fd;
           OP_LOG_DEBUG(logger, "Deleting heap to fd map: %p -> fd %d",
                        heap, fd);
           heap_fd_map[idx].heap = ~0ULL;
@@ -156,10 +158,9 @@ void OPHeapFSync(OPHeap* heap)
     fsync(fd);
 }
 
-static off_t GetFDSize(int fd)
+off_t GetFDSize(int fd)
 {
   struct stat heap_stat;
-  int stat_ret;
   if (fstat(fd, &heap_stat) == -1)
     {
       OP_LOG_ERROR(logger, "Error on fstat: %s",

--- a/opic/malloc/op_malloc.c
+++ b/opic/malloc/op_malloc.c
@@ -92,7 +92,7 @@ OPHeap* OPHeapOpen(const char *path, int flags)
   int fd;
   pthread_mutex_lock(&op_mutex);
 
-  fd = open(path, flags);
+  fd = open(path, flags, S_IRUSR | S_IWUSR);
   if (fd == -1)
     {
       OP_LOG_ERROR(logger, "Failed to open %s. %s",

--- a/opic/malloc/op_malloc.c
+++ b/opic/malloc/op_malloc.c
@@ -79,6 +79,142 @@ struct HeapFdEntry
 #define FDMAP_SIZE (1ULL<<12)
 static struct HeapFdEntry heap_fd_map[FDMAP_SIZE];
 
+static int OPHeapGetFD(OPHeap* heap);
+static void OPHeapPutFD(OPHeap* heap, int fd);
+static void OPHeapDelFD(OPHeap* heap);
+static off_t GetFDSize(int fd);
+static inline OPHeap* OPHeapOpenInternal(int fd);
+
+
+OPHeap* OPHeapOpen(const char *path, int flags)
+{
+  OPHeap* heap;
+  int fd;
+  pthread_mutex_lock(&op_mutex);
+
+  fd = open(path, flags);
+  if (fd == -1)
+    {
+      OP_LOG_ERROR(logger, "Failed to open %s. %s",
+                   path, strerror(errno));
+      pthread_mutex_unlock(&op_mutex);
+      return NULL;
+    }
+  heap = OPHeapOpenInternal(fd);
+  if (heap)
+    OPHeapPutFD(heap, fd);
+  pthread_mutex_unlock(&op_mutex);
+  return heap;
+}
+
+OPHeap* OPHeapOpenTmp()
+{
+  OPHeap* heap;
+  int fd;
+  FILE* pfile;
+  pthread_mutex_lock(&op_mutex);
+
+  pfile = tmpfile();
+  if (pfile == NULL)
+    {
+      OP_LOG_ERROR(logger, "Failed to create tmp file: %s",
+                   strerror(errno));
+      pthread_mutex_unlock(&op_mutex);
+      return NULL;
+    }
+  fd = fileno(pfile);
+  heap = OPHeapOpenInternal(fd);
+  if (heap)
+    OPHeapPutFD(heap, fd);
+  pthread_mutex_unlock(&op_mutex);
+  return heap;
+}
+
+void OPHeapMSync(OPHeap* heap)
+{
+  int fd;
+  off_t heap_size;
+  pthread_mutex_lock(&op_mutex);
+
+  fd = OPHeapGetFD(heap);
+  op_assert(fd != -1,
+            "All OPHeap should have a matching fd.\n");
+  heap_size = GetFDSize(fd);
+  if (!msync(heap, (size_t)heap_size, MS_SYNC))
+    {
+      OP_LOG_ERROR(logger, "msync on %p failed: %s",
+                   heap, strerror(errno));
+    }
+
+  pthread_mutex_unlock(&op_mutex);
+}
+
+void OPHeapClose(OPHeap* heap)
+{
+  OPHeapMSync(heap);
+
+  pthread_mutex_lock(&op_mutex);
+  OPHeapDelFD(heap);
+  munmap(heap, OPHEAP_SIZE);
+  pthread_mutex_unlock(&op_mutex);
+}
+
+
+void OPHeapStorePtr(OPHeap* heap, void* ptr, int pos)
+{
+  op_assert(heap == ObtainOPHeap(ptr), "Attempt to store ptr %p in OPHeap %p\n",
+            ptr, heap);
+  op_assert(pos < 8, "Can only store 8 root ptrs, but got pos = %d\n", pos);
+  opref_t ptr_base;
+  ptr_base = OPPtr2Ref(ptr);
+  heap->root_ptrs[pos] = ptr_base;
+}
+
+void* OPHeapRestorePtr(OPHeap* heap, int pos)
+{
+  op_assert(pos < 8, "Can only store 8 root ptrs, but got pos = %d\n", pos);
+  return OPRef2Ptr(heap, heap->root_ptrs[pos]);
+}
+
+// Used by allocator to expand the heap size.
+void OPHeapCheckExpandSize(OPHeap* heap, size_t size)
+{
+  int heap_fd;
+  off_t heap_size, expand_boundary;
+  uintptr_t heap_base;
+
+  pthread_mutex_lock(&op_mutex);
+
+  heap_fd = OPHeapGetFD(heap);
+  heap_size = GetFDSize(heap_fd);
+  expand_boundary = (off_t)size;
+  heap_base = (uintptr_t)heap;
+
+  if (heap_size < expand_boundary)
+    {
+      OP_LOG_DEBUG(logger,
+                   "Expanding OPHeap %p size to %" PRIx64,
+                   heap, (uint64_t)expand_boundary);
+      if (ftruncate(heap_fd, expand_boundary) == -1)
+        {
+          OP_LOG_FATAL(logger, "Expanding fd %d failed. %s",
+                       heap_fd, strerror(errno));
+          op_assert(0, "Fatal error");
+        }
+      if (mmap((void*)(heap_base + heap_size),
+               expand_boundary - heap_size,
+               PROT_READ | PROT_WRITE,
+               MAP_FILE | MAP_SHARED | MAP_FIXED,
+               heap_fd, heap_size) == MAP_FAILED)
+        {
+          OP_LOG_FATAL(logger, "Expand OPHeap %p failed. %s",
+                       heap, strerror(errno));
+          op_assert(0, "Fatal error");
+        }
+    }
+  pthread_mutex_unlock(&op_mutex);
+}
+
 static int OPHeapGetFD(OPHeap* heap)
 {
   uintptr_t uint_heap, idx_iter, idx, mask;
@@ -163,64 +299,6 @@ static off_t GetFDSize(int fd)
   return heap_stat.st_size;
 }
 
-void OPHeapMSync(OPHeap* heap)
-{
-  int fd;
-  off_t heap_size;
-  pthread_mutex_lock(&op_mutex);
-
-  fd = OPHeapGetFD(heap);
-  op_assert(fd != -1,
-            "All OPHeap should have a matching fd.\n");
-  heap_size = GetFDSize(fd);
-  if (!msync(heap, (size_t)heap_size, MS_SYNC))
-    {
-      OP_LOG_ERROR(logger, "msync on %p failed: %s",
-                   heap, strerror(errno));
-    }
-
-  pthread_mutex_unlock(&op_mutex);
-}
-
-
-void OPHeapCheckExpandSize(OPHeap* heap, size_t size)
-{
-  int heap_fd;
-  off_t heap_size, expand_boundary;
-  uintptr_t heap_base;
-
-  pthread_mutex_lock(&op_mutex);
-
-  heap_fd = OPHeapGetFD(heap);
-  heap_size = GetFDSize(heap_fd);
-  expand_boundary = (off_t)size;
-  heap_base = (uintptr_t)heap;
-
-  if (heap_size < expand_boundary)
-    {
-      OP_LOG_DEBUG(logger,
-                   "Expanding OPHeap %p size to %" PRIx64,
-                   heap, (uint64_t)expand_boundary);
-      if (ftruncate(heap_fd, expand_boundary) == -1)
-        {
-          OP_LOG_FATAL(logger, "Expanding fd %d failed. %s",
-                       heap_fd, strerror(errno));
-          op_assert(0, "Fatal error");
-        }
-      if (mmap((void*)(heap_base + heap_size),
-               expand_boundary - heap_size,
-               PROT_READ | PROT_WRITE,
-               MAP_FILE | MAP_SHARED | MAP_FIXED,
-               heap_fd, heap_size) == MAP_FAILED)
-        {
-          OP_LOG_FATAL(logger, "Expand OPHeap %p failed. %s",
-                       heap, strerror(errno));
-          op_assert(0, "Fatal error");
-        }
-    }
-  pthread_mutex_unlock(&op_mutex);
-}
-
 static inline
 OPHeap* OPHeapOpenInternal(int fd)
 {
@@ -297,77 +375,6 @@ OPHeap* OPHeapOpenInternal(int fd)
       return heap;
     }
   return NULL;
-}
-
-OPHeap* OPHeapOpen(const char *path, int flags)
-{
-  OPHeap* heap;
-  int fd;
-  pthread_mutex_lock(&op_mutex);
-
-  fd = open(path, flags);
-  if (fd == -1)
-    {
-      OP_LOG_ERROR(logger, "Failed to open %s. %s",
-                   path, strerror(errno));
-      pthread_mutex_unlock(&op_mutex);
-      return NULL;
-    }
-  heap = OPHeapOpenInternal(fd);
-  if (heap)
-    OPHeapPutFD(heap, fd);
-  pthread_mutex_unlock(&op_mutex);
-  return heap;
-}
-
-OPHeap* OPHeapOpenTmp()
-{
-  OPHeap* heap;
-  int fd;
-  FILE* pfile;
-  pthread_mutex_lock(&op_mutex);
-
-  pfile = tmpfile();
-  if (pfile == NULL)
-    {
-      OP_LOG_ERROR(logger, "Failed to create tmp file: %s",
-                   strerror(errno));
-      pthread_mutex_unlock(&op_mutex);
-      return NULL;
-    }
-  fd = fileno(pfile);
-  heap = OPHeapOpenInternal(fd);
-  if (heap)
-    OPHeapPutFD(heap, fd);
-  pthread_mutex_unlock(&op_mutex);
-  return heap;
-}
-
-void OPHeapClose(OPHeap* heap)
-{
-  OPHeapMSync(heap);
-
-  pthread_mutex_lock(&op_mutex);
-  OPHeapDelFD(heap);
-  munmap(heap, OPHEAP_SIZE);
-  pthread_mutex_unlock(&op_mutex);
-}
-
-
-void OPHeapStorePtr(OPHeap* heap, void* ptr, int pos)
-{
-  op_assert(heap == ObtainOPHeap(ptr), "Attempt to store ptr %p in OPHeap %p\n",
-            ptr, heap);
-  op_assert(pos < 8, "Can only store 8 root ptrs, but got pos = %d\n", pos);
-  opref_t ptr_base;
-  ptr_base = OPPtr2Ref(ptr);
-  heap->root_ptrs[pos] = ptr_base;
-}
-
-void* OPHeapRestorePtr(OPHeap* heap, int pos)
-{
-  op_assert(pos < 8, "Can only store 8 root ptrs, but got pos = %d\n", pos);
-  return OPRef2Ptr(heap, heap->root_ptrs[pos]);
 }
 
 /* op_malloc.c ends here */

--- a/opic/malloc/op_malloc_test.c
+++ b/opic/malloc/op_malloc_test.c
@@ -56,49 +56,49 @@
 #include "opic/malloc/objdef.h"
 #include "opic/op_malloc.h"
 
-extern void OPHeapShrinkCopy(OPHeap* heap);
+//extern void OPHeapShrinkCopy(OPHeap* heap);
 
 static void
 test_OPHeapShrinkShadow(void** context)
 {
-  OPHeap heap = {}, heap_control = {};
+  // OPHeap heap = {}, heap_control = {};
 
-  heap.hpage_num = HPAGE_BMAP_NUM * 64;
-  atomic_store(&heap.occupy_bmap[0], ~0ULL);
-  OPHeapShrinkCopy(&heap);
+  // heap.hpage_num = HPAGE_BMAP_NUM * 64;
+  // atomic_store(&heap.occupy_bmap[0], ~0ULL);
+  // OPHeapShrinkCopy(&heap);
 
-  heap_control.hpage_num = 64;
-  memset(heap_control.occupy_bmap, 0xff,
-         sizeof(uint64_t) * HPAGE_BMAP_NUM);
+  // heap_control.hpage_num = 64;
+  // memset(heap_control.occupy_bmap, 0xff,
+  //        sizeof(uint64_t) * HPAGE_BMAP_NUM);
 
-  assert_int_equal(heap_control.hpage_num, heap.hpage_num);
-  assert_memory_equal(&heap_control.occupy_bmap,
-                      &heap.occupy_bmap,
-                      sizeof(uint64_t) * HPAGE_BMAP_NUM);
+  // assert_int_equal(heap_control.hpage_num, heap.hpage_num);
+  // assert_memory_equal(&heap_control.occupy_bmap,
+  //                     &heap.occupy_bmap,
+  //                     sizeof(uint64_t) * HPAGE_BMAP_NUM);
 
-  heap.hpage_num = 96;
-  memset(heap.occupy_bmap, 0x00,
-         sizeof(uint64_t) * HPAGE_BMAP_NUM);
-  memset(heap.occupy_bmap, 0xff, sizeof(uint32_t));
-  OPHeapShrinkCopy(&heap);
+  // heap.hpage_num = 96;
+  // memset(heap.occupy_bmap, 0x00,
+  //        sizeof(uint64_t) * HPAGE_BMAP_NUM);
+  // memset(heap.occupy_bmap, 0xff, sizeof(uint32_t));
+  // OPHeapShrinkCopy(&heap);
 
-  heap_control.hpage_num = 32;
-  assert_int_equal(heap_control.hpage_num, heap.hpage_num);
-  assert_memory_equal(&heap_control.occupy_bmap,
-                      &heap.occupy_bmap,
-                      sizeof(uint64_t) * HPAGE_BMAP_NUM);
+  // heap_control.hpage_num = 32;
+  // assert_int_equal(heap_control.hpage_num, heap.hpage_num);
+  // assert_memory_equal(&heap_control.occupy_bmap,
+  //                     &heap.occupy_bmap,
+  //                     sizeof(uint64_t) * HPAGE_BMAP_NUM);
 
-  heap.hpage_num = 96;
-  memset(heap.occupy_bmap, 0x00,
-         sizeof(uint64_t) * HPAGE_BMAP_NUM);
-  atomic_store(&heap.occupy_bmap[0], 1);
-  OPHeapShrinkCopy(&heap);
+  // heap.hpage_num = 96;
+  // memset(heap.occupy_bmap, 0x00,
+  //        sizeof(uint64_t) * HPAGE_BMAP_NUM);
+  // atomic_store(&heap.occupy_bmap[0], 1);
+  // OPHeapShrinkCopy(&heap);
 
-  heap_control.hpage_num = 1;
-  assert_int_equal(heap_control.hpage_num, heap.hpage_num);
-  assert_memory_equal(&heap_control.occupy_bmap,
-                      &heap.occupy_bmap,
-                      sizeof(uint64_t) * HPAGE_BMAP_NUM);
+  // heap_control.hpage_num = 1;
+  // assert_int_equal(heap_control.hpage_num, heap.hpage_num);
+  // assert_memory_equal(&heap_control.occupy_bmap,
+  //                     &heap.occupy_bmap,
+  //                     sizeof(uint64_t) * HPAGE_BMAP_NUM);
 }
 
 static void
@@ -106,18 +106,18 @@ test_OPHeapIO(void** context)
 {
   OPHeap *heap, *heap_read;
   FILE* fd;
-  assert_true(OPHeapNew(&heap));
-  atomic_store(&heap->occupy_bmap[0], 1);
-  fd = tmpfile();
-  OPHeapWrite(heap, fd);
-  printf("write success\n");
-  fseek(fd, 0, SEEK_SET);
-  assert_true(OPHeapRead(&heap_read, fd));
-  printf("read success\n");
+  // heap = OPHeapOpenTmp();
+  // atomic_store(&heap->occupy_bmap[0], 1);
+  // fd = tmpfile();
+  // OPHeapWrite(heap, fd);
+  // printf("write success\n");
+  // fseek(fd, 0, SEEK_SET);
+  // assert_true(OPHeapRead(&heap_read, fd));
+  // printf("read success\n");
 
-  OPHeapShrinkCopy(heap);
+  // OPHeapShrinkCopy(heap);
   //assert_memory_equal(heap, heap_read, sizeof(OPHeap));
-  //OPHeapDestroy(heap);
+  //OPHeapClose(heap);
   //OPHeapDestroy(heap_read);
 }
 

--- a/opic/op_malloc.h
+++ b/opic/op_malloc.h
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <inttypes.h>
+#include <fcntl.h>
 #include <string.h>
 #include "opic/common/op_assert.h"
 #include "opic/common/op_macros.h"
@@ -88,8 +89,7 @@ typedef struct OPHeap OPHeap;
  *   int x;
  * };
  *
- * OPHeap* heap;
- * OPHeapNew(&heap);
+ * OPHeap* heap = OPHeapOpenTmp();
  *
  * struct A* a = OPMalloc(heap, sizeof(struct A));
  * struct B* b = OPMalloc(heap, sizeof(struct B));

--- a/opic/op_malloc.h
+++ b/opic/op_malloc.h
@@ -156,35 +156,23 @@ typedef uintptr_t oplenref_t;
  * @endcode
  *
  */
-bool OPHeapNew(OPHeap** heap_ref);
+OPHeap* OPHeapOpen(const char* path, int flags);
 
 /**
  * @relates OPHeap
- * @brief Writes the heap data to a file.
+ * @brief OPHeap constructor.
+ * @param heap_ref reference to a OPHeap pointer. The pointer is set
+ *        when the allocation succeeded.
+ * @return true when allocation succeeded, false otherwise.
  *
- * The file sizes would be multiple of 2MB. This is due to the internal
- * huge pages of OPHeap are 2MB, and OPHeap writes out file base on the
- * huge pages.
+ * @code
+ *   OPHeap* heap;
+ *   assert(OPHeapNew(&heap));
+ *   // now the heap pointer is set.
+ * @endcode
  *
- * @param heap OPHeap instance.
- * @param stream an opened FILE pointer.
  */
-void OPHeapWrite(OPHeap* heap, FILE* stream);
-
-/**
- * @relates OPHeap
- * @brief Memory map a file as an OPHeap instance. (read only)
- *
- * We only support read only access for now. The memory footprint of
- * the read OPHeap instance would have the same size as the file.
- * Write support and resizing the heap is on our roadmap.
- *
- * @param heap_ref reference to the heap pointer for assigning OPHeap
- *        instance.
- * @param stream an opened FILE pointer.
- * @return true when the read succeeded, false otherwise.
- */
-bool OPHeapRead(OPHeap** heap_ref, FILE* stream);
+OPHeap* OPHeapOpenTmp();
 
 /**
  * @relates OPHeap
@@ -192,7 +180,15 @@ bool OPHeapRead(OPHeap** heap_ref, FILE* stream);
  *
  * @param heap the OPHeap instance to destroy.
  */
-void OPHeapDestroy(OPHeap* heap);
+void OPHeapFSync(OPHeap* heap);
+
+/**
+ * @relates OPHeap
+ * @brief Destroy the OPHeap instance
+ *
+ * @param heap the OPHeap instance to destroy.
+ */
+void OPHeapClose(OPHeap* heap);
 
 /**
  * @relates OPHeap

--- a/opic/op_malloc.h
+++ b/opic/op_malloc.h
@@ -180,7 +180,7 @@ OPHeap* OPHeapOpenTmp();
  *
  * @param heap the OPHeap instance to destroy.
  */
-void OPHeapFSync(OPHeap* heap);
+void OPHeapMSync(OPHeap* heap);
 
 /**
  * @relates OPHeap


### PR DESCRIPTION
`OPHeapNew` and `OPHeapRead` merged to single API `OPHeapOpen`.
`OPHeapWrite` and `OPHeapDestroy` merged into `OPHeapClose`.

The API is cleaner in this way. (fewer types for users!) Also it solves the overcommit memory issue on linux. Because the API got simplified, I also updated the example in doc to show that how easy it is to use OPIC.